### PR TITLE
Add list of the examples to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,22 @@ Moreover, the folder [inputs/](./inputs/) contains some auxiliary files
 such as starting coordinates.
 
 
+## List of available examples
+
+| system     | method       | CV                 | script                                             | notebook |
+|------------|--------------|--------------------|----------------------------------------------------|----------| 
+| butane     | ANN          | dihedral angle     | [script.py](./hoomd-blue/classic/butane_ann/butane_ANN.py) | [![butane_ANN](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/SSAGESLabs/PySAGES-examples/blob/main/hoomd-blue/classic/butane_ann/butane_ANN.ipynb) |
+| butane     | FUNN         | dihedral angle     | [script.py](./hoomd-blue/classic/butane_funn/butane_FUNN.py) | [![butane_FUNN](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/SSAGESLabs/PySAGES-examples/blob/main/hoomd-blue/classic/butane_funn/butane_FUNN.ipynb) |
+| butane     | CFF          | dihedral angle     | [script.py](./hoomd-blue/classic/butane_cff/butane_CFF.py) | [![butane_CFF](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/SSAGESLabs/PySAGES-examples/blob/main/hoomd-blue/classic/butane_cff/butane_CFF.ipynb) |
+| butane     | SpectralABF  | dihedral angle     | [script.py](./hoomd-blue/classic/butane_spectral_abf/butane_SpectralABF.py) | [![butane_SpectralABF](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/SSAGESLabs/PySAGES-examples/blob/main/hoomd-blue/classic/butane_spectral_abf/butane_SpectralABF.ipynb) |
+| alanine dp | Metadynamics | 2 x dihedral angle | [script.py](./openmm/classic/alaninedipeptide_metad/adp_Metadynamics.py) | [![adp_Metadynamics](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/SSAGESLabs/PySAGES-examples/blob/main/openmm/classic/alaninedipeptide_metad/adp_Metadynamics.ipynb) |
+| alanine dp | SpectralABF  | 2 x dihedral angle | [script.py](./openmm/classic/alaninedipeptide_metad/adp_SpectralABF.py) | [![adp_SpectralABF](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/SSAGESLabs/PySAGES-examples/blob/main/openmm/classic/alaninedipeptide_metad/adp_SpectralABF.ipynb) |
+
+*ANN*  = Artificial Neural Network sampling
+
+*FUNN* = adpative Force-biasing sampling Using Neural Networks, or FUNN-ABF [[JCP **2018**, 148, 134108]](https://doi.org/10.1063/1.5020733)
+
+*CFF*  = Combined Force-Frequency sampling [[JCTC **2020**, 16, 1448−1455]](https://doi.org/10.1021/acs.jctc.9b00883)
+
+*SpectralABF* = Spectral Adaptive Biasing Force [[arXiv:2202.01876, **2022**]](https://arxiv.org/abs/2202.01876) 
+


### PR DESCRIPTION
I'm finding this useful to keep track of the examples I'm migrating/adding. Probably something like this is useful also later on (instead of having to browse the repo to find examples), but perhaps in some other form (than the current markdown table).